### PR TITLE
added retry to openml dataset download to prevent rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ To set up this repo, first ensure you have `python >= 3.11`. Then, run the follo
 git clone git@github.com:layer6ai-labs/TabDPT.git
 cd TabDPT
 pip install -e .
+pip install --group dev
+```
+
+Alternatively, if you are using a package manager such as `uv`, you can run
+```
+uv sync
 ```
 
 You may also need a C++ compiler such as `g++` for building dependencies. On Ubuntu, you can install it with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,4 +36,5 @@ Model = "https://huggingface.co/Layer6/TabDPT"
 [dependency-groups]
 dev = [
     "pytest>=8.4.1",
+    "tenacity>=9.1.2",
 ]

--- a/tabdpt_datasets/openml.py
+++ b/tabdpt_datasets/openml.py
@@ -65,7 +65,7 @@ class OpenMLDataset(Dataset):
 
     @retry(
         stop=stop_after_attempt(3),
-        # Wait strategy: Wait exponentially, starting at 0.5s, with a max of 10s
+        # Wait strategy: Wait exponentially, starting at 0.5s, with a max of 30s
         wait=wait_exponential(multiplier=0.5, max=30),
         retry=retry_if_exception_type(openml.exceptions.OpenMLServerError),
     )

--- a/tabdpt_datasets/openml.py
+++ b/tabdpt_datasets/openml.py
@@ -10,6 +10,7 @@ import numpy as np
 import openml
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder, OrdinalEncoder
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from .dataset import Dataset
 
@@ -62,6 +63,12 @@ class OpenMLDataset(Dataset):
             raise ValueError("Data not loaded yet")
         return self._openml_dataset
 
+    @retry(
+        stop=stop_after_attempt(3),
+        # Wait strategy: Wait exponentially, starting at 0.5s, with a max of 10s
+        wait=wait_exponential(multiplier=0.5, max=30),
+        retry=retry_if_exception_type(openml.exceptions.OpenMLServerError),
+    )
     def prepare_data(self, download_dir):
 
         openml.config.set_root_cache_directory(os.path.join(download_dir, "openml_cache"))


### PR DESCRIPTION
Retries openML api dataset preparation with an exponential decay if we're rate limited.

### Testing
Ran `python paper_evaluation.py` successfully
```
acc     0.884221
auc     0.929451
corr    0.841606
r2      0.745652
dtype: float64
```