### PR TITLE
Relax required versions to improve compatibility as a depdendency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository provides lightweight interface code to generate predictions on n
 
 TabDPT is available on [Hugging Face](https://huggingface.co/Layer6/TabDPT).
 
-To set up this repo, first ensure you have `python >= 3.11`. Then, run the following:
+To set up this repo, first ensure you have Python 3.10 or 3.11. Then, run the following:
 ```
 git clone git@github.com:layer6ai-labs/TabDPT.git
 cd TabDPT
@@ -183,9 +183,15 @@ For full details, please see our paper [*TabDPT: Scaling Tabular Foundation Mode
 
 ## Reproducing TabDPT Paper Numbers
 
-It is impossible to exactly replicate the results of TabDPT between runs.
+It is impossible to exactly replicate the results of TabDPT between runs, but this section describes how to generate results using the same evaluation approach as in the paper.
 
-However, running the `paper_evaluation.py` script will enable calculation of results similar to the paper. Run the following two commands:
+To install the dependency versions used in the paper, run
+```
+pip install .[reproduce-results]
+```
+This requires Python 3.11.
+
+Running the `paper_evaluation.py` script will enable calculation of results similar to the paper. Run the following two commands:
 ```
 python paper_evaluation.py --fold 0
 python paper_evaluation.py --fold 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,23 +9,33 @@ description = "TabDPT: Scaling Tabular Foundation Models on Real Data"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICEN[CS]E*"]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "appdirs>=1.4.4,<2.0",
-    "faiss-cpu==1.11.0",
-    "gdown==5.2.0",
+    "faiss-cpu>=1.11.0,<2.0",
+    "gdown>=5.2.0,<6.0",
     "huggingface-hub>=0.33.2,<1.0",
-    "numpy==2.3.0",
-    "omegaconf==2.3.0",
+    "numpy>=2.1.0,<3.0",
+    "omegaconf>=2.3.0,<3.0",
     "safetensors>=0.5.3,<1.0",
-    "scikit-learn==1.7.0",
-    "scipy==1.15.3",
-    "torch==2.7.1",
-    "tqdm==4.67.1",
-    "rliable==1.2.0",
+    "scikit-learn>=1.7.0,<2.0",
+    "scipy>=1.15.3,<2.0",
+    "torch>=2.7.1,<3.0",
+    "tqdm>=4.67.1,<5.0",
+    "rliable>=1.2.0,<2.0",
     "pandas>=2.3.2,<3.0",
     "openml>=0.15.1,<1.0",
     "jupyter>=1.1.1,<2.0"
+]
+
+[project.optional-dependencies]
+reproduce-results = [
+    "faiss-cpu==1.11.0",
+    "numpy==2.3.0",
+    "omegaconf==2.3.0",
+    "scikit-learn==1.7.0",
+    "scipy==1.15.3",
+    "torch==2.7.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
- Change all dependency types to ">=a.b.c,<{a+1}.0" format by default
- Allow Python 3.10
- Allow Numpy 2.1.*
- Add optional dependencies to more exactly replicate paper environment

Tested by installing a python environment and running paper_evaluation.py, results are very close to as before. Currently running the same test with Numpy 2.1.* explicitly installed instead of 2.2.*. Looked into extending to Python 3.9, but that would require code changes, so leaving it for now.